### PR TITLE
Update dictionary source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ DictionaryEntry entry = result[100];
 Console.WriteLine(entry.Headword); // af bränna
 Console.WriteLine(entry.PartOfSpeech); // vb
 Console.WriteLine(entry.GrammaticalAspect); // v
+Console.WriteLine(entry.Information); // empty string in this case, some entries contain additional information.
 Console.WriteLine(entry.Definition); // afbränna, genom eld förstöra. hans trähws the af brendhe [...] etc.
 
 // ToString is overwritten for generic presentation.

--- a/src/DictionaryEntry.cs
+++ b/src/DictionaryEntry.cs
@@ -9,21 +9,24 @@ public readonly struct DictionaryEntry
     [JsonPropertyName("a")]
     public string Headword { get; init; }
     [JsonPropertyName("b")]
-    public string PartOfSpeech { get; init; }
+    public List<string> PartOfSpeech { get; init; }
     [JsonPropertyName("c")]
     public string GrammaticalAspect { get; init; }
     [JsonPropertyName("d")]
-    public List<string> Definitions { get; init; }
+    public string Information { get; init; }
     [JsonPropertyName("e")]
+    public List<string> Definitions { get; init; }
+    [JsonPropertyName("f")]
     public List<string> AlternativeForms { get; init; }
 
     public override string ToString() => $"{Headword} - {Definitions[0]}";
 
-    public DictionaryEntry(string headword, string partOfSpeech, string grammaticalAspect, List<string> definitions, List<string> alternativeForms)
+    public DictionaryEntry(string headword, List<string> partOfSpeech, string grammaticalAspect, string information, List<string> definitions, List<string> alternativeForms)
     {
         Headword = headword;
         PartOfSpeech = partOfSpeech;
         GrammaticalAspect = grammaticalAspect;
+        Information = information;
         Definitions = definitions;
         AlternativeForms = alternativeForms;
     }

--- a/tests/DictionaryTest.cs
+++ b/tests/DictionaryTest.cs
@@ -24,21 +24,24 @@ public class DictionaryTest
         var result = dictionary.GetEntries();
 
         Assert.Equal("af bränna", result[100].Headword);
-        Assert.Equal("vb", result[100].PartOfSpeech);
+        Assert.Equal(new List<string> { "vb" }, result[100].PartOfSpeech);
         Assert.Equal("v.", result[100].GrammaticalAspect);
+        Assert.Equal("", result[100].Information);
         Assert.Equal("afbränna, genom eld förstöra. hans trähws the af brendhe  RK 2: 2757 . ib 1511. halff stadhen är affbrändh  BSH 5: 132 (  1506) . Jfr bränna af.", result[100].Definitions[0]);
         Assert.Equal(new List<string>(), result[100].AlternativeForms);
 
         Assert.Equal("annat thera", result[1000].Headword);
-        Assert.Equal("kn", result[1000].PartOfSpeech);
+        Assert.Equal(new List<string> { "kn" }, result[1000].PartOfSpeech);
         Assert.Equal("konj.", result[1000].GrammaticalAspect);
-        Assert.Equal(" (eg. n. af annar i förening med gen. pl. af pron. thän) antingen. annat thera . . . älla, antingen . . . eller. annat thera skal jach felle thegh dödhan eller tu mik  Di 218 .  &quot; maa han i noghraa mattho wara annath thera gwdh eller man Lg 3: 108. &quot;", result[1000].Definitions[0]);
+        Assert.Equal("", result[1000].Information);
+        Assert.Equal(" (eg. n. af annar i förening med gen. pl. af pron. thän) antingen. annat thera . . . älla, antingen . . . eller. annat thera skal jach felle thegh dödhan eller tu mik  Di 218 .  \" maa han i noghraa mattho wara annath thera gwdh eller man Lg 3: 108. \"", result[1000].Definitions[0]);
         Assert.Equal(new List<string>(), result[1000].AlternativeForms);
 
         Assert.Equal("löna", result[20000].Headword);
-        Assert.Equal("vb", result[20000].PartOfSpeech);
+        Assert.Equal(new List<string> { "vb" }, result[20000].PartOfSpeech);
         Assert.Equal("v.", result[20000].GrammaticalAspect);
-        Assert.Equal("löna, vedergälla. &quot; med personens dat. och ack. betecknande det för hvilket lön gifves. minom och ack. betecknande det för hvilket lön gifves. minom winom lönir iak lydhno oc älskogha mz miskund &quot; MB 1: 332 . hånom hans gif löna  KS 70 (112, 77) . gudh löne henne sin stora kärlek  Lg 807 .  KL 296 . han honom thz ille lönte  RK 2: 3459 . - pass. thz kan thöm aldrigh vardha lönt  Iv 4959 . - med personens dat. och ack. betecknande det som gifves ss lön. honum löna synda giäl  Al 2329 . - med personens dat. them löne  RK 2: 3216 .  &quot; löna wäl jlum &quot; Bil 104 .  &quot; iak lönir hwariom enom äptir sinne forskullan &quot; Bir 1: 381 .  MB 2: 369 .  &quot; om honum skwlde saa wordhe lönth for hans langlige . . . trotieniste &quot; BSH 4: 220 ( 1497) . - löna, aflöna. them som ey löna sino ärfuodhis folke rättelica  MP 2: 111 .  &quot; löne . . . af thy sama sinom piltom oc tiänarom &quot; Bir 5: 115 .  ib 116 .  &quot; sinom soldenärom skulu the ey vara pliktoghe antiggia harnisk. kost äller fordenskap til land ällir watn. ey oc gull äller päninga til them at löna &quot; MB 2: 242 .  ib 243 . - betala. badh löna sik  Bo 14 . - belöna. war gudh ther badhe lönar wälgerninga ok plicta synde  Bil 458 . ", result[20000].Definitions[0]);
+        Assert.Equal("", result[20000].Information);
+        Assert.Equal("löna, vedergälla. \" med personens dat. och ack. betecknande det för hvilket lön gifves. minom och ack. betecknande det för hvilket lön gifves. minom winom lönir iak lydhno oc älskogha mz miskund \" MB 1: 332 . hånom hans gif löna  KS 70 (112, 77) . gudh löne henne sin stora kärlek  Lg 807 .  KL 296 . han honom thz ille lönte  RK 2: 3459 . - pass. thz kan thöm aldrigh vardha lönt  Iv 4959 . - med personens dat. och ack. betecknande det som gifves ss lön. honum löna synda giäl  Al 2329 . - med personens dat. them löne  RK 2: 3216 .  \" löna wäl jlum \" Bil 104 .  \" iak lönir hwariom enom äptir sinne forskullan \" Bir 1: 381 .  MB 2: 369 .  \" om honum skwlde saa wordhe lönth for hans langlige . . . trotieniste \" BSH 4: 220 ( 1497) . - löna, aflöna. them som ey löna sino ärfuodhis folke rättelica  MP 2: 111 .  \" löne . . . af thy sama sinom piltom oc tiänarom \" Bir 5: 115 .  ib 116 .  \" sinom soldenärom skulu the ey vara pliktoghe antiggia harnisk. kost äller fordenskap til land ällir watn. ey oc gull äller päninga til them at löna \" MB 2: 242 .  ib 243 . - betala. badh löna sik  Bo 14 . - belöna. war gudh ther badhe lönar wälgerninga ok plicta synde  Bil 458 . ", result[20000].Definitions[0]);
         Assert.Equal(new List<string>{
             "lönar Bil 458 . ",
             "lönir MB 1: 332,  Bir 1: 381 . ",


### PR DESCRIPTION
Changes:
- Can have multiple parts of speech instead of one. Previously a string, now a list of strings
- Additional "Information" field, may contain additional grammar info
- Quotes in definitions are encoded differently for easier FE parsing.